### PR TITLE
remove superfluous assignment

### DIFF
--- a/lib/deep-freeze.js
+++ b/lib/deep-freeze.js
@@ -20,7 +20,7 @@
 function deepFreeze(object) {
   if (object) {
     var property, propertyKey;
-    object = Object.freeze(object);
+    Object.freeze(object);
     for (propertyKey in object) {
       if (object.hasOwnProperty(propertyKey)) {
         property = object[propertyKey];


### PR DESCRIPTION
Object.freeze() modifies the object in place, so no need to reassign